### PR TITLE
settings.json 新增斷線重新連線後傳送至指定公共傳點的參數

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,9 +1,11 @@
 {
-  "ip": "jp.mcfallout.net",                 
-  "port": "25565",                          
+  "ip": "jp.mcfallout.net",
+  "port": "25565",
   "username": "留白",
   "password": "留白",
   "auth": "microsoft",
   "language": "zh-tw",
-  "whitelist": ["白名單ID"]
+  "whitelist": [
+    "白名單ID"
+  ]
 }

--- a/settings.json
+++ b/settings.json
@@ -3,14 +3,24 @@
   "forward_DC_ID": "DC 數字ID",
   "attack": true,
   "Interval_ticks": 10,
-  "mob_list": ["witch","vindicator","vex","pillager","evoker"],
-  "enable_detect_interrupt":true,
+  "mob_list": [
+    "witch",
+    "vindicator",
+    "vex",
+    "pillager",
+    "evoker"
+  ],
+  "enable_detect_interrupt": true,
   "check_raid_cycleTime": 30000,
   "health": false,
   "enable_discard": true,
   "enable_discard_msg": false,
   "discarditem_cycleTime": 10000,
-  "stayItem_list": ["totem_of_undying","netherite_sword","diamond_sword"],
+  "stayItem_list": [
+    "totem_of_undying",
+    "netherite_sword",
+    "diamond_sword"
+  ],
   "enable_exchange_logs": false,
   "no_item_exchange_interval": 500,
   "item_exchange_interval": 800,
@@ -18,10 +28,16 @@
   "trade_announce_cycleTime": 5000,
   "enable_trade_content_cycle": true,
   "content_skip_count": 1,
-  "trade_content": [[""
-                    ,""],
-					["",
-					 ""]],
+  "trade_content": [
+    [
+      "",
+      ""
+    ],
+    [
+      "",
+      ""
+    ]
+  ],
   "enable_detect_broadcast": false,
   "enable_reply_msg": false,
   "clear_reply_id_delay_time": 600000,
@@ -34,5 +50,7 @@
   "enable_send_msg_to_channel": false,
   "directly_send_msg_to_dc": false,
   "channel_ID": "",
-  "bot_token": ""
+  "bot_token": "",
+  "enable_reconnect_teleportation": true,
+  "reconnect_public_teleportation_point_id": "Ah_Zheng_2"
 }


### PR DESCRIPTION
enable_reconnect_teleportation 是否要傳送
reconnect_public_teleportation_point 傳送的公傳ID

原因：這幾天伺服器斷線重新連線後Bot都會被傳到別的分流或是出生點，導致Bot死亡掉經驗或是就沒有掛到資源，所以想說可以加入這樣的功能，可以先在私人領地或是設施設定公共傳點的位置，只要斷線重連就將機器人傳送回定位點