### PR TITLE
修復：避免 Illegal characters in chat 錯誤

### DIFF
--- a/commands/publicity/announcement.ts
+++ b/commands/publicity/announcement.ts
@@ -1,7 +1,7 @@
 import { AnnounceInterface } from "../../models/modules";
 import { localizer } from "../../utils/localization";
 import { logger } from "../../utils/logger";
-import { settings } from "../../utils/util";
+import { replaceNewlines, settings } from "../../utils/util";
 import { bot } from "../main/bot";
 
 export let announcer:Announcer;
@@ -25,7 +25,7 @@ export class Announcer implements AnnounceInterface
         //將每一句間隔0.5秒發送出去
         this.trade_content.forEach((c, index) => {
             setTimeout(()=>{
-            bot.chat(`${c}`);
+            bot.chat(replaceNewlines(`${c}`));
             }, 500 * (index + 1));
         });
 

--- a/utils/util.ts
+++ b/utils/util.ts
@@ -253,3 +253,13 @@ export function getAvailablePort(startPort: number): Promise<number> {
         });
     });
 }
+
+/**
+<<<<<<< HEAD
+ * 替換所有換行符號 (U+000A, U+000D) 為空格
+ * @param { string } text 原始字串
+ * @returns { string } 處理過的字串
+ */
+export function replaceNewlines(text: string): string {
+    return text.replace(/(?:\r\n|\r|\n)/g, ' ');
+}

--- a/utils/util.ts
+++ b/utils/util.ts
@@ -255,7 +255,6 @@ export function getAvailablePort(startPort: number): Promise<number> {
 }
 
 /**
-<<<<<<< HEAD
  * 替換所有換行符號 (U+000A, U+000D) 為空格
  * @param { string } text 原始字串
  * @returns { string } 處理過的字串


### PR DESCRIPTION
# 修復：避免 Illegal characters in chat 錯誤

## 背景
Carriage Return 是 Unicode 字元 `U+000D`，包含在 Windows 換行序列中（CRLF），會觸發 Illegal characters in chat (\u000D)。

## 調整部分

- 加入 `replaceNewlines` 清除換行字元
- 宣傳時使用 `replaceNewlines` 清潔用戶設置的宣傳文字（在 `commands/publicity/announcement.ts`）
